### PR TITLE
Compatibility fix for Python <3.6

### DIFF
--- a/deepzoom/__init__.py
+++ b/deepzoom/__init__.py
@@ -532,7 +532,7 @@ def safe_open(path):
     # not a URL. This change is isolated to this function as we want the output
     # XML to still have the original input paths instead of absolute paths:
     has_scheme = bool(urlparse(path).scheme)
-    normalized_path = f"file://{os.path.abspath(path)}" if not has_scheme else path
+    normalized_path = ("file://%s" % os.path.abspath(path)) if not has_scheme else path
     return io.BytesIO(urllib.request.urlopen(normalized_path).read())
 
 

--- a/deepzoom/__init__.py
+++ b/deepzoom/__init__.py
@@ -434,7 +434,7 @@ class ImageCreator(object):
                     jpeg_quality = int(self.image_quality * 100)
                     tile.save(tile_file, "JPEG", quality=jpeg_quality)
                 else:
-                    tile.save(tile_file)
+                    tile.save(tile_file, self.descriptor.tile_format)
         # Create descriptor
         self.descriptor.save(destination)
 


### PR DESCRIPTION
f-strings were introduced in Python 3.6; however, we're still using mostly Python 3.5 and on some machines even 3.4. The one usage of an f-string in your project can be easily replaced to make it work in older Python versions.

Also, I added another commit to set the output format in case it isn't JPEG.