### PR TITLE
Add collection `tile_background_color` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Add `DeepZoomCollection` and `CollectionCreator` `tile_background_color`
+  parameter for setting background color of collection tiles. This can be useful
+  when working with images that don’t compose well on a black background
+  (default).
+
 ## Version 2.0.0a2 – January 16, 2020
 
 - Format code using [Black].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   parameter for setting background color of collection tiles. This can be useful
   when working with images that don’t compose well on a black background
   (default).
+- Respect `DeepZoomCollection` `tile_format` parameter.
 
 ## Version 2.0.0a2 – January 16, 2020
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ cd deepzoom.py
 python setup.py install
 ```
 
+## Development
+
+Install for local development:
+
+```
+python3 -m pip install -e .
+```
+
 ## Example
 
 ```bash
@@ -28,7 +36,6 @@ Powered by [OpenZoom][].
 ## License
 
 Licensed under the [New BSD Licence][bsd].
-
 
 [bsd]: http://www.opensource.org/licenses/bsd-license.php
 [openzoom]: http://openzoom.org

--- a/deepzoom/__init__.py
+++ b/deepzoom/__init__.py
@@ -170,6 +170,7 @@ class DeepZoomCollection(object):
         max_level=7,
         tile_size=256,
         tile_format="jpg",
+        tile_background_color="#000000",
         items=[],
     ):
         self.source = filename
@@ -177,6 +178,7 @@ class DeepZoomCollection(object):
         self.tile_size = tile_size
         self.max_level = max_level
         self.tile_format = tile_format
+        self.tile_background_color = tile_background_color
         self.items = deque(items)
         self.next_item_id = len(self.items)
         # XML
@@ -267,7 +269,9 @@ class DeepZoomCollection(object):
             column, row = self.get_tile_position(i, level, self.tile_size)
             tile_path = "%s/%s_%s.%s" % (level_path, column, row, self.tile_format)
             if not os.path.exists(tile_path):
-                tile_image = PIL.Image.new("RGB", (self.tile_size, self.tile_size))
+                tile_image = PIL.Image.new(
+                    "RGB", (self.tile_size, self.tile_size), self.tile_background_color
+                )
                 q = int(self.image_quality * 100)
                 tile_image.save(tile_path, "JPEG", quality=q)
             tile_image = PIL.Image.open(tile_path)
@@ -449,11 +453,13 @@ class CollectionCreator(object):
         max_level=7,
         tile_format="jpg",
         copy_metadata=False,
+        tile_background_color="#000000",
     ):
         self.image_quality = image_quality
         self.tile_size = tile_size
         self.max_level = max_level
         self.tile_format = tile_format
+        self.tile_background_color = tile_background_color
         # TODO
         self.copy_metadata = copy_metadata
 
@@ -465,6 +471,7 @@ class CollectionCreator(object):
             max_level=self.max_level,
             tile_size=self.tile_size,
             tile_format=self.tile_format,
+            tile_background_color=self.tile_background_color,
         )
         for image in images:
             collection.append(image)

--- a/deepzoom/__init__.py
+++ b/deepzoom/__init__.py
@@ -272,8 +272,11 @@ class DeepZoomCollection(object):
                 tile_image = PIL.Image.new(
                     "RGB", (self.tile_size, self.tile_size), self.tile_background_color
                 )
-                q = int(self.image_quality * 100)
-                tile_image.save(tile_path, "JPEG", quality=q)
+                if self.tile_format == "jpg":
+                    jpeg_quality = int(self.image_quality * 100)
+                    tile_image.save(tile_path, "JPEG", quality=jpeg_quality)
+                else:
+                    tile_image.save(tile_path)
             tile_image = PIL.Image.open(tile_path)
             source_path = "%s/%s/%s_%s.%s" % (
                 _get_files_path(path),


### PR DESCRIPTION
- Add `DeepZoomCollection` and `CollectionCreator` `tile_background_color`
  parameter for setting background color of collection tiles. This can be useful
  when working with images that don’t compose well on a black background
  (default).