### PR TITLE
Fix opening local files on windows in python 3.x

### DIFF
--- a/deepzoom/__init__.py
+++ b/deepzoom/__init__.py
@@ -544,7 +544,7 @@ def safe_open(path):
     # not a URL. This change is isolated to this function as we want the output
     # XML to still have the original input paths instead of absolute paths:
     has_scheme = bool(urlparse(path).scheme)
-    normalized_path = ("file://%s" % os.path.abspath(path)) if not has_scheme else path
+    normalized_path = ("file:%s" % urllib.request.pathname2url(os.path.abspath(path))) if not has_scheme else path
     return io.BytesIO(urllib.request.urlopen(normalized_path).read())
 
 


### PR DESCRIPTION
Fixes an issue when opening local files in Windows, where filepaths are loaded with the format:

```C:\some\path\to\a\file.jpg```

Whereas they are required to be of the format:

```C:/some/path/to/a/file.jpg```

Without this change, `safe_open` throws a `URLError` (file not found) in `urllib.open_local_file`


**Please note: This has _only_ been tested on Windows.**