### PR TITLE
Pillow: Use newer resampling filter constants

### DIFF
--- a/deepzoom/__init__.py
+++ b/deepzoom/__init__.py
@@ -54,15 +54,14 @@ from collections import deque
 
 NS_DEEPZOOM = "http://schemas.microsoft.com/deepzoom/2008"
 
-DEFAULT_RESIZE_FILTER = PIL.Image.ANTIALIAS
+DEFAULT_RESIZE_FILTER = PIL.Image.LANCZOS
 DEFAULT_IMAGE_FORMAT = "jpg"
 
 RESIZE_FILTERS = {
-    "cubic": PIL.Image.CUBIC,
     "bilinear": PIL.Image.BILINEAR,
     "bicubic": PIL.Image.BICUBIC,
     "nearest": PIL.Image.NEAREST,
-    "antialias": PIL.Image.ANTIALIAS,
+    "lanczos": PIL.Image.LANCZOS,
 }
 
 IMAGE_FORMATS = {
@@ -309,14 +308,14 @@ class DeepZoomCollection(object):
                     if w != e_w or h != e_h:
                         # Resize incorrect tile to correct size
                         source_image = source_image.resize(
-                            (e_w, e_h), PIL.Image.ANTIALIAS
+                            (e_w, e_h), DEFAULT_RESIZE_FILTER
                         )
                         # Store new dimensions
                         w, h = e_w, e_h
                 else:
                     w = int(math.ceil(w * 0.5))
                     h = int(math.ceil(h * 0.5))
-                    source_image.thumbnail((w, h), PIL.Image.ANTIALIAS)
+                    source_image.thumbnail((w, h), DEFAULT_RESIZE_FILTER)
             column, row = self.get_position(i)
             x = (column % images_per_tile) * level_size
             y = (row % images_per_tile) * level_size
@@ -405,7 +404,7 @@ class ImageCreator(object):
         if self.descriptor.width == width and self.descriptor.height == height:
             return self.image
         if (self.resize_filter is None) or (self.resize_filter not in RESIZE_FILTERS):
-            return self.image.resize((width, height), PIL.Image.ANTIALIAS)
+            return self.image.resize((width, height), DEFAULT_RESIZE_FILTER)
         return self.image.resize((width, height), RESIZE_FILTERS[self.resize_filter])
 
     def tiles(self, level):
@@ -596,7 +595,7 @@ def main():
         "--resize_filter",
         dest="resize_filter",
         default=DEFAULT_RESIZE_FILTER,
-        help="Type of filter for resizing (bicubic, nearest, bilinear, antialias (best). Default: antialias",
+        help="Type of filter for resizing (bicubic, nearest, bilinear, lanczos (best). Default: lanczos",
     )
 
     (options, args) = parser.parse_args()


### PR DESCRIPTION
With Pillow 10.0.0, `PIL.Image.CUBIC` and `PIL.Image.ANTIALIAS` were removed. Instead, `PIL.Image.BICUBIC` and `PIL.Image.LANCZOS` respectively should be used.